### PR TITLE
支持多个servant

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ $nodeInfo = \Tars\Utils::parseNodeInfo($locatorString);
 	'iPort' => 2345
 ]
 ```
+
+## Changelog
+### v0.3.0(2019-06-21)
+- 支持多个servant

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
   "name": "phptars/tars-utils",
   "description": "tars的php辅助文件",
-  "version":"0.2.0",
+  "version":"0.3.0",
   "authors": [
     {
       "name": "Chen Liang",
       "email": "cedricliang21@gmail.com"
+    },
+    {
+      "name": "Yong Zhang",
+      "email": "bob_zy@yeah.net"
     }
   ],
   "minimum-stability": "dev",


### PR DESCRIPTION
支持多个servant
1. 使用swoole addListener 做底层支持
2. 支持一个服务部署多个obj，分别使用tars 或 http 协议
3. services.php 格式调整，返回以objName 为key 的二维数组。
4.  protocolName, serverType, isTimer 不在从私有模板中读取，需要在services.php中指定
5. demo见TarsActDemo下的QD.UserService 服务（timer见tars-timer-server服务）。